### PR TITLE
Add GetVehicleLicensePlate

### DIFF
--- a/src/Open-SAMP-API/Client/SAMPFunctions.cpp
+++ b/src/Open-SAMP-API/Client/SAMPFunctions.cpp
@@ -82,3 +82,26 @@ EXPORT int Client::SAMPFunctions::GetPlayerIDByName(const char *name)
 	return -1;
 }
 
+EXPORT int Client::SAMPFunctions::GetVehicleLicensePlate(char *&licensePlate, int max_len)
+{
+	SERVER_CHECK(0)
+
+	Utils::Serializer serializerIn, serializerOut;
+
+	serializerIn << Shared::PipeMessages::GetVehicleLicensePlate;
+
+	if (Utils::PipeClient(serializerIn, serializerOut).success())
+	{
+		std::string out;
+		serializerOut >> out;
+
+		if (!out.length())
+			return 0;
+
+		strcpy_s(licensePlate, max_len, out.c_str());
+		return 1;
+	}
+
+	return 0;
+}
+

--- a/src/Open-SAMP-API/Client/SAMPFunctions.hpp
+++ b/src/Open-SAMP-API/Client/SAMPFunctions.hpp
@@ -10,5 +10,6 @@ namespace Client
 		EXPORT int AddChatMessage(const char *msg);
 		EXPORT int GetPlayerNameByID(int id, char *&playername, int max_len);
 		EXPORT int GetPlayerIDByName(const char *name);
+		EXPORT int GetVehicleLicensePlate(char *&licensePlate, int max_len);
 	}
 }

--- a/src/Open-SAMP-API/Game/Game.cpp
+++ b/src/Open-SAMP-API/Game/Game.cpp
@@ -113,6 +113,7 @@ void initGame()
 		BIND(ShowGameText);
 		BIND(AddChatMessage);
 		BIND(GetPlayerNameByID);
+		BIND(GetVehicleLicensePlate);
 
 		BIND(ReadMemory);
 

--- a/src/Open-SAMP-API/Game/Messagehandler.cpp
+++ b/src/Open-SAMP-API/Game/Messagehandler.cpp
@@ -392,6 +392,16 @@ void Game::MessageHandler::GetPlayerNameByID(Utils::Serializer& serializerIn, Ut
 	}
 }
 
+void Game::MessageHandler::GetVehicleLicensePlate(Utils::Serializer& serializerIn, Utils::Serializer& serializerOut)
+{
+	if (const char *ptr = Game::SAMP::getLicensePlate()) {
+		WRITE(std::string(ptr));
+	}
+	else{
+		WRITE(std::string(""));
+	}
+}
+
 void Game::MessageHandler::ReadMemory(Utils::Serializer& serializerIn, Utils::Serializer& serializerOut)
 {
 	READ(unsigned int, address);

--- a/src/Open-SAMP-API/Game/Messagehandler.hpp
+++ b/src/Open-SAMP-API/Game/Messagehandler.hpp
@@ -55,6 +55,7 @@ namespace Game
 		void ShowGameText(Utils::Serializer& serializerIn, Utils::Serializer& serializerOut);
 		void AddChatMessage(Utils::Serializer& serializerIn, Utils::Serializer& serializerOut);
 		void GetPlayerNameByID(Utils::Serializer& serializerIn, Utils::Serializer& serializerOut);
+		void GetVehicleLicensePlate(Utils::Serializer& serializerIn, Utils::Serializer& serializerOut);
 
 		void ReadMemory(Utils::Serializer& serializerIn, Utils::Serializer& serializerOut);
 	}

--- a/src/Open-SAMP-API/Game/SAMP/SAMP.cpp
+++ b/src/Open-SAMP-API/Game/SAMP/SAMP.cpp
@@ -112,3 +112,24 @@ bool Game::SAMP::addChatMessage(const char *text)
 	__asm add esp, 8
 	return true;
 }
+
+const char *Game::SAMP::getLicensePlate()
+{
+	// TODO: Find general pattern
+
+	static auto addr = g_dwModuleBase + 0x13C54C;
+
+	if (addr == 0)
+		return nullptr;
+
+	DWORD dwAddr = *(DWORD *)(addr) + 0x9b;
+
+	if (dwAddr == 0)
+		return nullptr;
+	
+	char *chLcPlate = new char[20];
+	if (ReadProcessMemory(GetCurrentProcess(), (LPCVOID)dwAddr, chLcPlate, 20, NULL) == FALSE)
+		return nullptr;
+
+	return chLcPlate;
+}

--- a/src/Open-SAMP-API/Game/SAMP/SAMP.hpp
+++ b/src/Open-SAMP-API/Game/SAMP/SAMP.hpp
@@ -10,5 +10,6 @@ namespace Game
 		bool sendChat(const char *msg);
 		bool showGameText(const char *text, int iTime, int iStyle);
 		bool addChatMessage(const char *text);
+		const char *getLicensePlate();
 	}
 }

--- a/src/Open-SAMP-API/Shared/PipeMessages.hpp
+++ b/src/Open-SAMP-API/Shared/PipeMessages.hpp
@@ -58,6 +58,7 @@ namespace Shared
 		ShowGameText,
 		AddChatMessage,
 		GetPlayerNameByID,
+		GetVehicleLicensePlate,
 
 		// Memory functions
 		ReadMemory


### PR DESCRIPTION
Addresses #9.

Sadly, we need to access the SAMP-internal data as it overrides GTA's license plate generation in some way.

I wasn't able to find a re-usable pattern to auto-detect the address, so for now, it's a hardcoded value that works in SAMP 0.3.7. Any help welcome!
