### PR TITLE
With use_window=0, postpone load until after SAMP is fully loaded

### DIFF
--- a/src/Open-SAMP-API/Client/Client.cpp
+++ b/src/Open-SAMP-API/Client/Client.cpp
@@ -57,6 +57,12 @@ EXPORT int Client::Client::Init()
 	{
 		std::string szSearchName = GetParam("process");
 		dwPId = Utils::Process::pidByProcessName(szSearchName);
+
+		if (dwPId != 0) {
+			DWORD dwPIdStartup = Utils::Process::pidByWindowName("GTA: San Andreas");
+			if (dwPId == dwPIdStartup)
+				return 0;
+		}
 	}
 	else
 	{

--- a/src/Open-SAMP-API/Client/Client.cpp
+++ b/src/Open-SAMP-API/Client/Client.cpp
@@ -59,6 +59,8 @@ EXPORT int Client::Client::Init()
 		dwPId = Utils::Process::pidByProcessName(szSearchName);
 
 		if (dwPId != 0) {
+			// We want to wait until after SAMP is fully loaded (that is, the window is
+			// no longer named "GTA: San Andreas") so we can actually access all SAMP features
 			DWORD dwPIdStartup = Utils::Process::pidByWindowName("GTA: San Andreas");
 			if (dwPId == dwPIdStartup)
 				return 0;


### PR DESCRIPTION
As you know, connecting to a SAMP server does the following:
1. `gta_sa.exe` is started with the initial window name `GTA: San Andreas`, showing the SAMP loading screen
2. When the loading screen disappears, the window is renamed to `GTA:SA:MP` (_or something else_)

So, here's the problem:
If the API is set to `use_window=1`, everything is alright because it is only injected after step 2

But, if the API is set to `use_window=0, process=gta_sa.exe` instead, it is already injected at step 1.
Therefore, `Game::SAMP::initSAMP()` is called before SAMP is fully loaded and the `findPattern` calls in there won't work yet. That is, neither `ShowDialog` nor `IsDialogOpen` work correctly.

This fix postpones the injection until after step 2 in this case, by explicitly ignoring the `GTA: San Andreas` window.
I guess there is a better fix, but that's up to you guys...