### PR TITLE
Consolidate all functions that read GTA command line arguments

### DIFF
--- a/src/Open-SAMP-API/Client/SAMPFunctions.hpp
+++ b/src/Open-SAMP-API/Client/SAMPFunctions.hpp
@@ -5,6 +5,7 @@ namespace Client
 {
 	namespace SAMPFunctions
 	{
+		int ReadGTACmdArgument(char * option, char *& str, int max_len);
 		EXPORT int GetServerIP(char *&ip, int max_len);
 		EXPORT int GetServerPort();
 		EXPORT int SendChat(const char *msg);


### PR DESCRIPTION
In `SAMPFunctions`, we have three functions which are very similar: `GetPlayerName`, `GetServerIP` and `GetServerPort` all get the GTA command line and look for a specific argument in there (`-n`, `-h` and `-p`, respectively).
In this PR, I've created a common helper function `ReadGTACmdArgument` which contains this logic.

In `GetServerPort`, where the result is converted to int, I also replaced `atoi` with `strtol` so we can check for conversion-related errors, too.


Tested this locally, everything's working just fine.