### PR TITLE
 Clean up memory after ReadGTACmdArgument/GetServerPort calls

### DIFF
--- a/src/Open-SAMP-API/Client/SAMPFunctions.cpp
+++ b/src/Open-SAMP-API/Client/SAMPFunctions.cpp
@@ -5,8 +5,8 @@
 #include <boost/scope_exit.hpp>
 
 int Client::SAMPFunctions::ReadGTACmdArgument(const char *option, char *&str, const int max_len) {
-	auto *szCommandLine = new char[512];
-	ZeroMemory(szCommandLine, 512);
+	auto *szCommandLine = new char[513];
+	ZeroMemory(szCommandLine, 513);
 
 	if (GTAFunctions::GetGTACommandLine(szCommandLine, 512) == 0) {
 		delete[] szCommandLine;
@@ -42,8 +42,8 @@ EXPORT int Client::SAMPFunctions::GetServerIP(char *&ip, const int max_len)
 
 EXPORT int Client::SAMPFunctions::GetServerPort()
 {
-	auto *portStr = new char[6];
-	ZeroMemory(portStr, 6);
+	auto *portStr = new char[7];
+	ZeroMemory(portStr, 7);
 
 	BOOST_SCOPE_EXIT_ALL(portStr) {
 		delete[] portStr;
@@ -161,8 +161,8 @@ EXPORT int Client::SAMPFunctions::GetPlayerName(char *&playername, const int max
 
 EXPORT int Client::SAMPFunctions::GetPlayerId()
 {
-	auto *szName = new char[25];
-	ZeroMemory(szName, 25);
+	auto *szName = new char[26];
+	ZeroMemory(szName, 26);
 
 	GetPlayerName(szName, 25);
 

--- a/src/Open-SAMP-API/Client/SAMPFunctions.cpp
+++ b/src/Open-SAMP-API/Client/SAMPFunctions.cpp
@@ -4,8 +4,8 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/scope_exit.hpp>
 
-int Client::SAMPFunctions::ReadGTACmdArgument(char *option, char *&str, int max_len) {
-	char *szCommandLine = new char[512];
+int Client::SAMPFunctions::ReadGTACmdArgument(const char *option, char *&str, const int max_len) {
+	auto *szCommandLine = new char[512];
 	ZeroMemory(szCommandLine, 512);
 
 	if (GTAFunctions::GetGTACommandLine(szCommandLine, 512) == 0) {
@@ -16,33 +16,33 @@ int Client::SAMPFunctions::ReadGTACmdArgument(char *option, char *&str, int max_
 	// The gta_sa.exe process of SAMP looks something like this:
 	// PATH/TO/gta_sa.exe -n NAME -h IP -p PORT
 	// In here, we attempt to read any attributes that were passed in there
-	char *context = NULL;
-	char *token = strtok_s(szCommandLine, " ", &context);
+	char *context = nullptr;
+	auto *token = strtok_s(szCommandLine, " ", &context);
 
-	while (token != NULL) {
-		token = strtok_s(NULL, " ", &context);
+	while (token != nullptr) {
+		token = strtok_s(nullptr, " ", &context);
 		if (strcmp(token, option) == 0)
 			break;
 	}
 
-	if (token != NULL)
+	if (token != nullptr)
 	{
-		token = strtok_s(NULL, " ", &context);
+		token = strtok_s(nullptr, " ", &context);
 		strcpy_s(str, max_len, token);
 	}
 
 	delete[] szCommandLine;
-	return token != NULL;
+	return token != nullptr;
 }
 
-EXPORT int Client::SAMPFunctions::GetServerIP(char *&ip, int max_len)
+EXPORT int Client::SAMPFunctions::GetServerIP(char *&ip, const int max_len)
 {
 	return ReadGTACmdArgument("-h", ip, max_len);
 }
 
 EXPORT int Client::SAMPFunctions::GetServerPort()
 {
-	char *portStr = new char[6];
+	auto *portStr = new char[6];
 	ZeroMemory(portStr, 6);
 
 	BOOST_SCOPE_EXIT_ALL(portStr) {
@@ -51,7 +51,7 @@ EXPORT int Client::SAMPFunctions::GetServerPort()
 
 	if (ReadGTACmdArgument("-p", portStr, 6)) {
 		errno = 0;
-		int port = strtol(portStr, NULL, 10);
+		const int port = strtol(portStr, nullptr, 10);
 		if (errno != 0)
 			return -1;
 		return port;
@@ -154,19 +154,19 @@ EXPORT int Client::SAMPFunctions::GetPlayerIDByName(const char *name)
 	return -1;
 }
 
-EXPORT int Client::SAMPFunctions::GetPlayerName(char *&playername, int max_len)
+EXPORT int Client::SAMPFunctions::GetPlayerName(char *&playername, const int max_len)
 {
 	return ReadGTACmdArgument("-n", playername, max_len);
 }
 
 EXPORT int Client::SAMPFunctions::GetPlayerId()
 {
-	char *szName = new char[25];
+	auto *szName = new char[25];
 	ZeroMemory(szName, 25);
 
 	GetPlayerName(szName, 25);
 
-	int iID = GetPlayerIDByName(szName);
+	const int iID = GetPlayerIDByName(szName);
 
 	delete[] szName;
 

--- a/src/Open-SAMP-API/Client/SAMPFunctions.hpp
+++ b/src/Open-SAMP-API/Client/SAMPFunctions.hpp
@@ -5,7 +5,7 @@ namespace Client
 {
 	namespace SAMPFunctions
 	{
-		int ReadGTACmdArgument(char * option, char *& str, int max_len);
+		int ReadGTACmdArgument(const char * option, char *& str, int max_len);
 		EXPORT int GetServerIP(char *&ip, int max_len);
 		EXPORT int GetServerPort();
 		EXPORT int SendChat(const char *msg);


### PR DESCRIPTION
As noted in #45. @agrippa1994 

Actual fix is in f31ac13c0fcce26a9bdd0b28b30bd2b818b31f69, and then there's also some general cleanup in f3c52c2c.
